### PR TITLE
Alter SignMessageResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ export interface WebLNProvider {
   signMessage(message: string): Promise<SignMessageResponse>;
 
   /* Shows the user a view that verifies a signed message */
-  verifyMessage(signedMessage: string, rawMessage: string): Promise<void>;
+  verifyMessage(signature: string, message: string): Promise<void>;
 }
 ```
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -39,5 +39,5 @@ export interface WebLNProvider {
   sendPayment(paymentRequest: string): Promise<SendPaymentResponse>;
   makeInvoice(args: string | number | RequestInvoiceArgs): Promise<RequestInvoiceResponse>;
   signMessage(message: string): Promise<SignMessageResponse>;
-  verifyMessage(signedMessage: string, rawMessage: string): Promise<void>;
+  verifyMessage(signature: string, message: string): Promise<void>;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -29,7 +29,8 @@ export interface RequestInvoiceResponse {
 }
 
 export interface SignMessageResponse {
-  signedMessage: string;
+  message: string;
+  signature: string;
 }
 
 export interface WebLNProvider {


### PR DESCRIPTION
This changes the expected return of a `signMessage` call from:
```ts
export interface SignMessageResponse {
  signedMessage: string;
}
```
to
```ts
export interface SignMessageResponse {
  message: string;
  signature: string;
}
```

This is for three reasons:
1. LND returns `{ "signature": "..." }`, and this library tends to try to follow LND's nomenclature for consistency. Calling it `signedMessage` initially was a mistake.
2. Including the message in the response is useful for a few reasons
    * If we ever accept non-string inputs as messages (e.g. JSON serializable content) this will ensure that you receive the message as it was serialized, to avoid things like whitespace or encoding issues.
    * It makes it easier for callback functions to not have to pass around state, e.g.
    ```ts
    webln.signMessage('testMessage').then(handleSignedMessage);

    function handleSignedMessage(response) {
      // Has all of the information needed, didn't need to explicitly be passed the message
    }
    ```
3. There are no implementations or apps using signed messages yet (to my knowledge) so now is the time to make changes.

---

I'm going to merge this as-is for now to prep Joule for the changes, since it's the only active implementation that I'm aware of, but I'll delay publishing WebLN 0.2.0 for a bit in case anyone has any issues with this change.