### PR TITLE
feat: add webln.request

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
-import { WebLNProvider } from './provider';
-import { MissingProviderError } from './errors';
+import { WebLNProvider } from "./provider";
+import { MissingProviderError } from "./errors";
 
 /**
  * Everything needed to get and set providers on the client.
@@ -12,19 +12,25 @@ export interface GetProviderParameters {
   pubkey?: string;
 }
 
-export function requestProvider(_: GetProviderParameters = {}): Promise<WebLNProvider> {
+// TODO: expose webln.enable() response in return type
+export function requestProvider(
+  _: GetProviderParameters = {}
+): Promise<WebLNProvider> {
   return new Promise((resolve, reject) => {
-    if (typeof window === 'undefined') {
-      return reject(new Error('Must be called in a browser context'));
+    if (typeof window === "undefined") {
+      return reject(new Error("Must be called in a browser context"));
     }
 
     const webln: WebLNProvider = (window as any).webln;
     if (!webln) {
-      return reject(new MissingProviderError('Your browser has no WebLN provider'));
+      return reject(
+        new MissingProviderError("Your browser has no WebLN provider")
+      );
     }
 
-    webln.enable()
+    webln
+      .enable()
       .then(() => resolve(webln))
-      .catch(err => reject(err));
+      .catch((err) => reject(err));
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export * from './client';
-export * from './provider';
-export * from './errors';
+export * from "./client";
+export * from "./provider";
+export * from "./errors";
+export * from "./request-method";

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -2,6 +2,9 @@
  * Everything needed to implement your own provider.
  */
 
+import { RequestMethod } from "./request-method";
+import { AdditionalString } from "./types";
+
 export interface WebLNNode {
   alias: string;
   pubkey: string;
@@ -10,6 +13,9 @@ export interface WebLNNode {
 
 export interface GetInfoResponse {
   node: WebLNNode;
+  version: string;
+  supports: ("lightning" | AdditionalString)[];
+  methods: RequestMethod[];
 }
 
 export interface SendPaymentResponse {
@@ -39,12 +45,21 @@ export interface SignMessageResponse {
   signature: string;
 }
 
+export interface EnableResponse {
+  enabled: boolean;
+  remember: boolean;
+}
+
 export interface WebLNProvider {
-  enable(): Promise<void>;
+  enable(): Promise<EnableResponse>;
   getInfo(): Promise<GetInfoResponse>;
   sendPayment(paymentRequest: string): Promise<SendPaymentResponse>;
   keysend(args: KeysendArgs): Promise<SendPaymentResponse>;
-  makeInvoice(args: string | number | RequestInvoiceArgs): Promise<RequestInvoiceResponse>;
+  makeInvoice(
+    args: string | number | RequestInvoiceArgs
+  ): Promise<RequestInvoiceResponse>;
   signMessage(message: string): Promise<SignMessageResponse>;
   verifyMessage(signature: string, message: string): Promise<void>;
+  // TODO: improve request typings
+  request(method: RequestMethod, args?: unknown): Promise<unknown>;
 }

--- a/src/request-method.ts
+++ b/src/request-method.ts
@@ -1,0 +1,26 @@
+import { AdditionalString } from "./types";
+
+export type RequestMethod =
+  | "getinfo"
+  | "listchannels"
+  | "listinvoices"
+  | "channelbalance"
+  | "walletbalance"
+  | "openchannel"
+  | "connectpeer"
+  | "disconnectpeer"
+  | "estimatefee"
+  | "getchaninfo"
+  | "getnetworkinfo"
+  | "getnodeinfo"
+  | "gettransactions"
+  | "listpayments"
+  | "listpeers"
+  | "lookupinvoice"
+  | "queryroutes"
+  | "verifymessage"
+  | "sendtoroute"
+  | "decodepayreq"
+  | "routermc"
+  | "addinvoice"
+  | AdditionalString;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+// Workaround for code completion to account for values this library doesn't know about yet.
+// This allows TypeScript to understand that AdditionalString is a string that is distinct from the string literal type.
+export type AdditionalString = string & { _additionalString?: never };


### PR DESCRIPTION
This PR adds some extra type definitions for further functionality exposed by the Alby extension, most importantly the new webln.request method.

The arguments and return types for this method are not typed yet, but I will aim to do this to improve the developer experience of using WebLN.